### PR TITLE
Add optional `sound_chip_written` callback

### DIFF
--- a/source/bus-main-m68k.c
+++ b/source/bus-main-m68k.c
@@ -1307,6 +1307,10 @@ void M68kWriteCallbackWithCycle(const void* const user_data, const cc_u32f addre
 
 						/* Alter the PSG's state */
 						PSG_DoCommand(&clownmdemu->psg, low_byte);
+
+						/* Notify the frontend of the write. */
+						if (frontend_callbacks->sound_chip_written != NULL)
+							frontend_callbacks->sound_chip_written((void*)frontend_callbacks->user_data, CLOWNMDEMU_SOUND_CHIP_PSG, 0, low_byte, target_cycle.cycle);
 					}
 					break;
 

--- a/source/bus-z80.c
+++ b/source/bus-z80.c
@@ -156,9 +156,17 @@ void Z80WriteCallbackWithCycle(const void* const user_data, const cc_u16f addres
 			SyncFM(callback_user_data, target_cycle);
 
 			if ((address & 1) == 0)
+			{
 				FM_DoAddress(&clownmdemu->fm, (address & 2) != 0 ? 1 : 0, value);
+			}
 			else
+			{
 				FM_DoData(&clownmdemu->fm, value);
+
+				/* Notify the frontend of the write. */
+				if (clownmdemu->callbacks->sound_chip_written != NULL)
+					clownmdemu->callbacks->sound_chip_written((void*)clownmdemu->callbacks->user_data, clownmdemu->fm.state.port == 0 ? CLOWNMDEMU_SOUND_CHIP_FM_PORT0 : CLOWNMDEMU_SOUND_CHIP_FM_PORT1, clownmdemu->fm.state.address, value, target_cycle.cycle);
+			}
 
 			break;
 

--- a/source/clownmdemu.h
+++ b/source/clownmdemu.h
@@ -106,6 +106,13 @@ typedef enum ClownMDEmu_CDDAMode
 	CLOWNMDEMU_CDDA_PLAY_REPEAT
 } ClownMDEmu_CDDAMode;
 
+typedef enum ClownMDEmu_SoundChip
+{
+	CLOWNMDEMU_SOUND_CHIP_FM_PORT0, /* YM2612 channels 1-3 and DAC */
+	CLOWNMDEMU_SOUND_CHIP_FM_PORT1, /* YM2612 channels 4-6 */
+	CLOWNMDEMU_SOUND_CHIP_PSG       /* SN76489 */
+} ClownMDEmu_SoundChip;
+
 typedef struct ClownMDEmu_Configuration
 {
 	ClownMDEmu_Region region;
@@ -253,6 +260,9 @@ typedef struct ClownMDEmu_Callbacks
 	void (*save_file_closed)(void *user_data);
 	cc_bool (*save_file_removed)(void *user_data, const char *filename);
 	cc_bool (*save_file_size_obtained)(void *user_data, const char *filename, size_t *size);
+
+	/* May be NULL. */
+	void (*sound_chip_written)(void *user_data, ClownMDEmu_SoundChip chip, cc_u8f address, cc_u8f data, cc_u32f cycle);
 } ClownMDEmu_Callbacks;
 
 typedef struct ClownMDEmu
@@ -461,7 +471,8 @@ namespace ClownMDEmuCXX
 			Callback_SaveFileWritten,
 			Callback_SaveFileClosed,
 			Callback_SaveFileRemoved,
-			Callback_SaveFileSizeObtained
+			Callback_SaveFileSizeObtained,
+			Callback_SoundChipWritten
 		};
 
 		static void Callback_ColourUpdated(void* const user_data, const cc_u16f index, const cc_u16f colour)
@@ -538,6 +549,11 @@ namespace ClownMDEmuCXX
 		static cc_bool Callback_SaveFileSizeObtained(void* const user_data, const char* const filename, std::size_t* const size)
 		{
 			return static_cast<Derived*>(static_cast<Emulator*>(user_data))->SaveFileSizeObtained(filename, size);
+		}
+
+		static void Callback_SoundChipWritten(void* const user_data, const ClownMDEmu_SoundChip chip, const cc_u8f address, const cc_u8f data, const cc_u32f cycle)
+		{
+			static_cast<Derived*>(static_cast<Emulator*>(user_data))->SoundChipWritten(chip, address, data, cycle);
 		}
 
 		/*************/


### PR DESCRIPTION
This adds an optional callback to `ClownMDEmu_Callbacks` that fires upon every YM2612 and SN76489 register write, along with the master-clock cycle (relative to the current frame) at which the write occurred. It is intended for sound-ripping features such as VGM logging; a companion frontend PR implements a VGM recorder on top of it.

Notes:
- The callback is NULL-guarded, so existing consumers are unaffected.
- `FM_DoData` and `PSG_DoCommand` each have a single call site, so every write path is covered: 68k FM writes route through `Z80WriteCallbackWithCycle`, and Z80 PSG writes route through `M68kWriteCallbackWithCycle`.
- The C++ wrapper wires the new callback like the existing ones.
